### PR TITLE
fix: unsubscribe the page subscription onDestroy to avoid memory leak

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -38,11 +38,9 @@ export function initFlash(
   flashStores.set(page, context);
   updateStore(context, get(page).data.flash);
 
-  onDestroy(() => flashStores.delete(page));
-
   let lastUpdate: 'page' | null = null;
 
-  page.subscribe(async ($page) => {
+  const pageSubscription = page.subscribe(async ($page) => {
     //console.log('🚀 ~ page.subscribe: ', $page.data.flash?.[0].text, lastUpdate);
     if (!browser && $page.data.flash !== undefined) {
       updateFlash(page);
@@ -57,6 +55,11 @@ export function initFlash(
         }
       });
     }
+  });
+
+  onDestroy(() => {
+    pageSubscription();
+    flashStores.delete(page);
   });
 
   afterNavigate(async (nav) => {


### PR DESCRIPTION
This PR fixes a memory leak on the client side.
If you navigate away from a page that uses the "initFlash" function, the page subscription will never finish and for every form action with the "use:enhance" it will throw an error:

<img width="511" alt="image" src="https://github.com/ciscoheat/sveltekit-flash-message/assets/37917090/a3dcf4d6-f3f8-4230-ab02-967cdde9cee4">

I created a repro: https://github.com/stLmpp/flash-svelte-page-subscription
1. Install the dependencies
2. Run npm run dev
3. Use the anchor to navigate to the "other" route
4. Click the button to submit the form
5. Check the console to see the errors