### PR TITLE
fix: firefox warnings (cookies misusing the recommended "SameSite")

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -189,7 +189,7 @@ function clearCookieAndUpdateIfNewData(
   newData: App.PageData['flash'] | undefined
 ) {
   if (browser) {
-    document.cookie = varName + `=; Max-Age=0; Path=${path};`;
+    document.cookie = varName + `=; Max-Age=0; Path=${path}; SameSite=Strict;`;
   }
   if (newData === undefined) return;
 


### PR DESCRIPTION
This fixes #24, essentially when we are removing the cookie from the client we didn't set the SameSite attribute added Strict for now seem that's what the default and it doesn't matter as I believe it gets removed anyway.

Also the issue with the cookie not showing at all it's because it gets cleared really fast that it's impossible to inspect it or debug it, since this is called when we make request, hence overriding the flashCookieOption won't do anything for example if we override the `flashCookieOptions.maxAge = 2147483647;` It will override it but at the end of the day it will be removed so fast that it's redundant or not needed. 

```js
function clearCookieAndUpdateIfNewData(
  context: FlashContext,
  newData: App.PageData['flash'] | undefined
) {
  if (browser) {
    document.cookie = varName + `=; Max-Age=0; Path=${path}; SameSite=Strict;`;
  }
  if (newData === undefined) return;

  context.store.update((flash) => {
    //console.log("🚀 ~ file: client.ts:120 ~ updateStore ~ newData:", newData)

    // Need to do a per-element comparison here, since update will be called
    // when going to the same route, while keeping the old flash message,
    // making it display multiple times.
    if (!context.options.clearArray && Array.isArray(newData)) {
      if (Array.isArray(flash)) {
        if (
          flash.length > 0 &&
          newData.length > 0 &&
          flash[flash.length - 1] === newData[newData.length - 1]
        ) {
          return flash;
        } else {
          return flash.concat(newData) as unknown as App.PageData['flash'];
        }
      }
    }

    return newData;
  });
}
```
