### PR TITLE
Improve types for the load wrapper

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -19,19 +19,19 @@ export const flashCookieOptions: CookieSerializeOptions = {
 /**
  * @deprecated Renamed to loadFlash.
  */
-export function loadFlashMessage<S extends ServerLoad, E extends ServerLoadEvent>(cb: S) {
-  return loadFlash<S, E>(cb);
+export function loadFlashMessage<E extends ServerLoadEvent, R>(load: (event: E) => R) {
+  return loadFlash(load);
 }
 
 /**
  * Retrieves the flash message from the previous request.
  * Use as a wrapper around a top-level load function, usually in a +layout.server.ts file.
  */
-export function loadFlash<S extends ServerLoad, E extends ServerLoadEvent>(cb: S) {
+export function loadFlash<E extends ServerLoadEvent, R>(load: (event: E) => R) {
   return async (event: E) => {
     const flash = _loadFlash(event).flash;
-    const loadFunction = await cb(event);
-    return { flash, ...loadFunction } as ReturnType<S>;
+    const loadReturn = await load(event);
+    return { flash, ...loadReturn } as typeof loadReturn;
   };
 }
 


### PR DESCRIPTION
Before this change you would just get a "generic" `ServerLoadEvent`, i.e. without params or route id set:

![grafik](https://github.com/user-attachments/assets/ac23608b-5087-40b5-b9dc-c3302a6cb208)

Adding `satisfies LayoutServerLoad` to the passed function works but gives an error about the route id:

![grafik](https://github.com/user-attachments/assets/3686ba87-5eff-45b6-993a-1fbd8c54ec34)

      Type 'string | null' is not assignable to type 'LayoutRouteId'.
        Type 'string' is not assignable to type 'LayoutRouteId'.ts(2345)

After this change no error is shown and not even the satisfies is needed (at least for autocomplete; I think eslint still requires it).