### PR TITLE
fix(types): correct loadFlash return type to avoid Promise<Promise<T>>

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -31,7 +31,7 @@ export function loadFlash<S extends ServerLoad, E extends ServerLoadEvent>(cb: S
   return async (event: E) => {
     const flash = _loadFlash(event).flash;
     const loadFunction = await cb(event);
-    return { flash, ...loadFunction } as ReturnType<S>;
+    return { flash, ...loadFunction } as Awaited<ReturnType<S>>;
   };
 }
 


### PR DESCRIPTION
## Summary

The `loadFlash` / `loadFlashMessage` wrappers are currently typed such that the outer async arrow function returns `Promise<ReturnType<S>>` where `ReturnType<S>` is itself a `Promise<T>` (since `S extends ServerLoad` and async load functions return a Promise). The resulting `Promise<Promise<T>>` shape:

- Is tolerated by stock `tsc` (which implicitly flattens in many cases).
- Fails strict checkers. In particular, TypeScript's Go-native preview (`tsgo` via `svelte-check --tsgo`) rejects it when the wrapped load is annotated as or assigned to `LayoutServerLoad`:

```
src/routes/+layout.server.ts:14:14
Error: Type '(event: ServerLoadEvent<...>) => Promise<Promise<{ ... }>>'
  is not assignable to type 'LayoutServerLoad'.
```

## Fix

Replace the internal cast `as ReturnType<S>` with `as Awaited<ReturnType<S>>` inside the async arrow. The outer `async` already wraps the return in one `Promise`, so the final exported function type becomes:

```ts
(event: E) => Promise<Awaited<ReturnType<S>>>
```

— the shape SvelteKit's `LayoutServerLoad` / `ServerLoad` contract expects, and equivalent behavior for existing consumers that were relying on implicit Promise flattening.

## Why now

With `svelte-check` v4.4+ shipping the `--tsgo` flag, more projects are opting into the Go-native compiler for faster type checking. The current `ReturnType<S>` cast silently breaks on that path even though the runtime behavior is correct.

## Test plan

- [x] Applied the equivalent patch locally via `pnpm patch`; `svelte-check --tsgo` goes from 1 error → 0 errors on a SvelteKit app using `loadFlash` as the top-level layout load wrapper.
- [x] Stock `svelte-check` remains clean (0 errors) after the change — no regression for existing consumers.
- [x] Downstream route `PageParentData` / `LayoutServerParentData` inference preserved (earlier attempts using `as unknown as LayoutServerLoad` cascaded into ~9 child-route errors; this fix does not).

No runtime code is changed — only the type cast on the returned object literal.